### PR TITLE
inquire() directory test

### DIFF
--- a/inquire-dir.f90
+++ b/inquire-dir.f90
@@ -1,0 +1,7 @@
+! Result of INQUIRE on a directory
+! True: GNU, NAG, NVF, XLF, f18, Cray
+! False: Intel
+logical :: is_file
+inquire(file=".", exist=is_file)
+print *, is_file
+end


### PR DESCRIPTION
This patch inclues a test to report the existence of a directory.

  inquire(file="foo", exist=is_file)

I suppose there is some ambiguity in the standard as to whether a directory is a file.

This is not a standalone test, since a method to create the directory `foo` is not provided.  AFAIK, there is no simple platform-independent way to do this.  But a POSIX wrapper to `mk/rmdir` or a `system()` call could be included.